### PR TITLE
fix: use semgrep ce and add commit-msg-check

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Preflight Checks
 on:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
   push:
     branches: [ "main" ]
@@ -20,5 +20,7 @@ jobs:
         copyright-license-detector: true   # default: true
         pr-check-emails: true              # default: true
         dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        commit-msg-check: true             # default: true
+
+        # sub-char-limit: 50
+        # desc-char-limit: 72

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.2.0
     with:
         # ✅ Preflight Checkers
         repolinter: true                   # default: true
@@ -20,7 +20,4 @@ jobs:
         copyright-license-detector: true   # default: true
         pr-check-emails: true              # default: true
         dependency-review: true            # default: true
-        commit-msg-check: true             # default: true
-
-        # sub-char-limit: 50
-        # desc-char-limit: 72
+        commit-msg-check: false             # default: false


### PR DESCRIPTION
## Summary
Enhanced the workflow by adding a new check:  [commit-msg-check](https://github.com/qualcomm/commit-msg-check-action)
Default Settings
```
commit-msg-check: true 
sub-char-limit: 50
desc-char-limit: 72
```
Additionally, removed pull_request_target since SEMGREP_APP_TOKEN is no longer required. We will now use the community edition of Semgrep.
