### PR TITLE
Update GitHub workflow to use QC Preflight Checks v2.0.0

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,24 +1,22 @@
-name: Qualcomm Preflight Checks
+name: QC Preflight Checks
+
 on:
-  pull_request_target:
-    branches: [ "main" ]
+  pull_request:
   push:
-    branches: [ "main" ]
+    branches: [main]
   workflow_dispatch:
 
-permissions:
- contents: read
- security-events: write
-
 jobs:
-  qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/qcom-preflight-checks-reusable-workflow.yml@v1.1.4
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2.0.0
     with:
-        # ✅ Preflight Checkers
-        repolinter: true                   # default: true
-        semgrep: true                      # default: true
-        copyright-license-detector: true   # default: true
-        pr-check-emails: true              # default: true
-        dependency-review: true            # default: true
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+    permissions:
+      contents: read
+      security-events: write

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Common actions and workflows for Qualcomm repositories.
 | [qualcomm/commit-emails-check-action](https://github.com/qualcomm/commit-emails-check-action) | GitHub action for checking email addresses in PR/Push commits | @quic-nasserg |
 | [qualcomm/copyright-license-checker-action](https://github.com/qualcomm/copyright-license-checker-action) | GitHub action for copyright and license issues in PR/Push commits | @targoy-qti |
 | [actions/dependency-review-action](https://github.com/actions/dependency-review-action) | Detects vulnerable dependencies and invalid licenses in PRs | @igibek |
+| [qualcomm/commit-msg-check-action](https://github.com/qualcomm/commit-msg-check-action) | GitHub action for validating commit message format and content | @ynancher |
 
 Each check can be individually disabled when not applicable to your project, however in general they should not be disabled. Create an [Issue](https://github.com/qualcomm/qcom-actions/issues) if you run into any issues.
 
@@ -34,7 +35,7 @@ To start using `qcom-preflight-checks` use one of the below options to create th
 
 #### How to Configure
 
-If you need to disable individual checks, open `./github/workflows/qcom-preflight-checks.yml` in your repository and set the check to `false`. E.g. if you want to disable `semgrep`, you can set `semgrep: false` in the `with` section of the workflow. Default value is `true` for all checkers.
+If you need to disable individual checks, open `./github/workflows/qcom-preflight-checks.yml` in your repository and set the check to `false`. E.g. if you want to disable `semgrep`, you can set `enable-semgrep-scan: false` in the `with` section of the workflow. To disable the commit message check, set `enable-commit-msg-check: false`. Default value is `true` for all checkers except for commit message check which defaults to `false`.
 
 ## Versioning Workflows and Actions
 


### PR DESCRIPTION
## Summary

- Rename workflow from "Qualcomm Preflight Checks" to "QC Preflight Checks"
- Change trigger from pull_request_target to pull_request
- Update reusable workflow reference from v1.1.4 to v2.0.0
- Update parameter naming convention to use enable-* prefix
- Add enable-commit-msg-check parameter (set to false)
- Move permissions section inside the job definition