### PR TITLE
Create qcom-preflight-checks-for-pkg.yml for pkg repos

### DIFF
--- a/.github/workflows/qcom-preflight-checks-for-pkg.yml
+++ b/.github/workflows/qcom-preflight-checks-for-pkg.yml
@@ -1,0 +1,23 @@
+name: QC Preflight Checks for pkg-* repos
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    name: Run QC Preflight Checks
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    with:
+      enable-semgrep-scan: true
+      enable-dependency-review: true
+      enable-repolinter-check: true
+      enable-copyright-license-check: true
+      enable-commit-email-check: true
+      enable-commit-msg-check: false
+      enable-armor-checkers: false
+
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
This will be used with an enterprise ruleset to require pkg- repos to pass qc preflight checks centrally. They have many branches, and this will allow the workflow file to be managed centrally.